### PR TITLE
Proposed enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea/
+bacon.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "argminmax"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +204,52 @@ dependencies = [
  "num-traits",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -276,8 +370,9 @@ dependencies = [
 
 [[package]]
 name = "csv-compare"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "clap",
  "colored",
  "indicatif",
  "polars",
@@ -1281,6 +1376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1473,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "csv-compare"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.7", features = ["derive"] }
 colored = "2"
 indicatif = "0.17.7"
 polars = { version = "0.34.2", features = ["lazy"] }
 
 [profile.release]
-strip = true
+strip = true  # Automatically strip symbols from the binary.
+lto = true  # Enable link-time optimization.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CSV Compare
-This is a little tool that solves a very specific problem: Comparing the content of 2 different CSV (comma separated values) files, taking in account that the rows could be in different order (not the columns).
+This is a little tool that solves a very specific problem: Comparing the content of 2 different CSV (comma separated values) files, taking in account that the rows and columns could be in different order. Also there's a way to enforce the strict order of columns (**--strict-order** flag).
 
 To do that comparison, the 2 CSV files are compared column by column, using the first column as identifier for sorting.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
-use std::env;
-use std::process::exit;
 use colored::*;
 use indicatif::ProgressBar;
 use polars::frame::DataFrame;
-use polars::prelude::{col, IndexOfSchema, IntoVec, LazyCsvReader, LazyFileListReader, LazyFrame, SortOptions};
+use polars::prelude::{
+    col, IndexOfSchema, IntoVec, LazyCsvReader, LazyFileListReader, LazyFrame, SortOptions,
+};
+use std::env;
+use std::process::exit;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const EXECUTABLE_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,15 +29,24 @@ fn main() {
     let second_file_cols = get_column_names(&second_file_lf);
 
     if first_file_cols.len() != second_file_cols.len() {
-        println!("{} : {}","FILES ARE DIFFERENT".red(), "Different number of columns".on_bright_red());
+        println!(
+            "{} : {}",
+            "FILES ARE DIFFERENT".red(),
+            "Different number of columns".on_bright_red()
+        );
         exit(2);
     }
 
     for i in 0..first_file_cols.len() {
         if first_file_cols[i] != second_file_cols[i] {
-            println!("{}: {} #{} => {} != {}",
-                "FILES ARE DIFFERENT".red(), "Different names for column".red(),
-                     i+1, first_file_cols[i].bold().yellow(), second_file_cols[i].bold().blue());
+            println!(
+                "{}: {} #{} => {} != {}",
+                "FILES ARE DIFFERENT".red(),
+                "Different names for column".red(),
+                i + 1,
+                first_file_cols[i].bold().yellow(),
+                second_file_cols[i].bold().blue()
+            );
             exit(2);
         }
     }
@@ -43,22 +54,28 @@ fn main() {
     let sorting_column = &first_file_cols[0];
     let columns_to_iterate = (first_file_cols.len() - 1) as u64;
 
-    println!("Comparing content of each column in both files when sorted by column: {} ...", sorting_column);
+    println!(
+        "Comparing content of each column in both files when sorted by column: {} ...",
+        sorting_column
+    );
     let progress_bar = ProgressBar::new(columns_to_iterate);
     for i in 1..first_file_cols.len() {
         let column_name = &first_file_cols[i];
 
-        let first_data_frame = get_sorted_data_frame_for_column(&first_file_lf,
-                                                          sorting_column, column_name);
+        let first_data_frame =
+            get_sorted_data_frame_for_column(&first_file_lf, sorting_column, column_name);
 
-        let second_data_frame = get_sorted_data_frame_for_column(&second_file_lf,
-                                                           sorting_column, column_name);
+        let second_data_frame =
+            get_sorted_data_frame_for_column(&second_file_lf, sorting_column, column_name);
 
         if !first_data_frame.frame_equal_missing(&second_data_frame) {
-            println!("{}: {} {} {}", "FILES ARE DIFFERENT".red(),
-                     "Values for column".red(),
-                     column_name.on_bright_red(),
-                     "are different".red());
+            println!(
+                "{}: {} {} {}",
+                "FILES ARE DIFFERENT".red(),
+                "Values for column".red(),
+                column_name.on_bright_red(),
+                "are different".red()
+            );
 
             exit(3);
         }
@@ -66,7 +83,11 @@ fn main() {
     }
     progress_bar.finish();
 
-    println!("{} {}", "FILES ARE IDENTICAL WHEN SORTED BY COLUMN:".green(), sorting_column.green());
+    println!(
+        "{} {}",
+        "FILES ARE IDENTICAL WHEN SORTED BY COLUMN:".green(),
+        sorting_column.green()
+    );
 }
 
 fn get_lazy_frame(file_path: &str) -> LazyFrame {
@@ -78,7 +99,8 @@ fn get_lazy_frame(file_path: &str) -> LazyFrame {
 }
 
 fn get_column_names(lazy_frame: &LazyFrame) -> Vec<String> {
-    let schema = lazy_frame.clone()
+    let schema = lazy_frame
+        .clone()
         .limit(1)
         .collect()
         .expect("Couldn't parse first CSV file")
@@ -87,8 +109,13 @@ fn get_column_names(lazy_frame: &LazyFrame) -> Vec<String> {
     schema.get_names().into_vec()
 }
 
-fn get_sorted_data_frame_for_column(lazy_frame: &LazyFrame, sorting_column: &String, column: &String) -> DataFrame {
-    lazy_frame.clone()
+fn get_sorted_data_frame_for_column(
+    lazy_frame: &LazyFrame,
+    sorting_column: &String,
+    column: &String,
+) -> DataFrame {
+    lazy_frame
+        .clone()
         .select([col(sorting_column), col(column)])
         .sort(sorting_column, SortOptions::default())
         .collect()


### PR DESCRIPTION
- Code formatted with `cargo fmt` before the pull request.
- Add [clap](https://crates.io/crates/clap) to manage the input arguments.
- Simplified logic to assert that both dataframes have the same columns.
- Allow unordered list of columns by default. 
  - Example: Frame1 with `[a, b, c]` and Frame2 with `[a, c, b]` are considered now to have the same columns.
- Enforce strict column order via `--strict-column-order` (or `-s` for short) flag if needed. 
  - Example: Frame1 with `[a, b, c]` and Frame2 with `[a, c, b]` will no longer considered to have the same columns.
- Add `lto` flag to release build in `Cargo.toml`.